### PR TITLE
[css][xs]: fix for main css error

### DIFF
--- a/ckanext/datopian/templates/admin/config.html
+++ b/ckanext/datopian/templates/admin/config.html
@@ -13,7 +13,7 @@
 
       {{ form.input('ckan.site_title', id='field-ckan-site-title', label=_('Site Title'), value=data['ckan.site_title'], error=error, classes=['control-medium']) }}
 
-      {{ form.select('ckan.main_css', id='field-ckan-main-css', label=_('Style'), options=styles, selected=data['ckan.main_css'], error=error) }}
+      {{ form.select('ckan.theme', id='field-ckan-main-css', label=_('Style'), options=styles, selected=data['ckan.theme'], error=error) }}
 
       {{ form.input('ckan.site_description', id='field-ckan-site-description', label=_('Site Tag Line'), value=data['ckan.site_description'], error=error, classes=['control-medium']) }}
 

--- a/ckanext/datopian/templates/base.html
+++ b/ckanext/datopian/templates/base.html
@@ -68,9 +68,8 @@
     {%- block styles %}
 
       {# TODO: store just name of asset instead of path to it. #}
-      {% set main_css = h.get_rtl_css() if h.is_rtl_language() else g.main_css %}
-      {# strip '/base/' prefix and '.css' suffix #}
-      {% asset main_css[6:-4] %}
+      {% set theme = h.get_rtl_theme() if h.is_rtl_language() else g.theme %}
+      {% asset theme %}
 
 
     {% endblock %}

--- a/ckanext/datopian/templates/macros/autoform.html
+++ b/ckanext/datopian/templates/macros/autoform.html
@@ -12,7 +12,7 @@ Example
 
   {% set form_info = [
       {'name': 'ckan.site_title', 'control': 'input', 'label': _('Site Title'), 'placeholder': ''},
-      {'name': 'ckan.main_css', 'control': 'select', 'options': styles, 'label': _('Style'), 'placeholder': ''},
+      {'name': 'ckan.theme', 'control': 'select', 'options': styles, 'label': _('Style'), 'placeholder': ''},
       {'name': 'ckan.site_description', 'control': 'input', 'label': _('Site Tag Line'), 'placeholder': ''},
       {'name': 'ckan.site_logo', 'control': 'input', 'label': _('Site Tag Logo'), 'placeholder': ''},
       {'name': 'ckan.site_about', 'control': 'markdown', 'label': _('About'), 'placeholder': _('About page text')},


### PR DESCRIPTION
Error: Whenever sysadmin config page will be updated, it throws this error
```
The form contains invalid entries:
message: Configuration option(s) 'ckan.main_css' can not be updated
```
ckan version: 2.9

Resolution:
ckan.main_css didn't work since it is not not using CSS files directly anymore in version 2.9.
Fixed in this PR https://github.com/ckan/ckan/pull/6817 by replacing to theme.
Since some of our projects are using this 2.9 version, and fix is already there, however we are using some old templates such as `admin/config`.